### PR TITLE
Web no error on load

### DIFF
--- a/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
+++ b/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
@@ -280,7 +280,7 @@ public class BluetoothLEClient extends Plugin {
 
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 byte[] characteristicValue = characteristic.getValue();
-                addProperty(ret, keyValue, JSArray.from(characteristicValue));
+                addProperty(ret, keyValue, jsByteArray(characteristicValue));
                 call.resolve(ret);
             } else {
                 call.error(keyErrorValueRead);
@@ -309,13 +309,10 @@ public class BluetoothLEClient extends Plugin {
                 return;
             }
 
-            JSObject ret = new JSObject();
-
             if (status == BluetoothGatt.GATT_SUCCESS) {
-
+                JSObject ret = new JSObject();
                 byte[] value = characteristic.getValue();
-                addProperty(ret, keyValue, JSArray.from(value));
-
+                addProperty(ret, keyValue, jsByteArray(value));
             } else {
                 call.error(keyErrorValueWrite);
             }
@@ -342,7 +339,7 @@ public class BluetoothLEClient extends Plugin {
             }
 
             JSObject ret = new JSObject();
-            addProperty(ret, keyValue, JSArray.from(characteristicValue));
+            addProperty(ret, keyValue, jsByteArray(characteristicValue));
 
             notifyListeners(characteristic16BitUuid.toString(), ret);
         }
@@ -370,7 +367,7 @@ public class BluetoothLEClient extends Plugin {
                 JSObject ret = new JSObject();
 
                 byte[] value = descriptor.getValue();
-                addProperty(ret, keyValue, JSArray.from(value));
+                addProperty(ret, keyValue, jsByteArray(value));
 
                 call.resolve(ret);
             } else {
@@ -405,7 +402,7 @@ public class BluetoothLEClient extends Plugin {
 
             if (status == BluetoothGatt.GATT_SUCCESS) {
 
-                addProperty(ret, keyValue, JSArray.from(value));
+                addProperty(ret, keyValue, jsByteArray(value));
                 call.resolve(ret);
 
             } else {
@@ -1373,10 +1370,19 @@ public class BluetoothLEClient extends Plugin {
 
     }
 
-    private ArrayList<UUID> getServiceUuids(JSArray serviceUuidArray) {
+    private JSArray jsByteArray(byte[] bytes) {
+        int[] ints = new int[bytes.length];
+
+        for (int i=0; i<bytes.length; i++) {
+            ints[i] = bytes[i] & 0xff;
+        }
+
+        return JSArray.from(ints);
+    }
 
 
         ArrayList<UUID> serviceUuids = new ArrayList<>();
+    private List<UUID> getServiceUuids(JSArray serviceUuidArray) {
 
         if (serviceUuidArray == null) {
             return serviceUuids;
@@ -1417,6 +1423,24 @@ public class BluetoothLEClient extends Plugin {
 
         if (bytes == null || bytes.length == 0) {
             return null;
+        }
+
+        return bytes;
+    }
+
+    private byte[] toByteArray(JSArray arrayValue) {
+        if (arrayValue == null) {
+            return null;
+        }
+
+        byte[] bytes = new byte[arrayValue.length()];
+
+        for (int i=0; i<bytes.length; i++) {
+            try {
+                bytes[i] = (byte) arrayValue.get(i);
+            } catch (JSONException e) {
+                bytes[i] = 0;
+            }
         }
 
         return bytes;

--- a/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
+++ b/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
@@ -904,21 +904,21 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
 
-        UUID service128BitUuid = get128BitUUID(propertyCharacteristic);
+        UUID service128BitUuid = get128BitUUID(propertyService);
         BluetoothGattService service = gatt.getService(service128BitUuid);
 
         if (service == null) {

--- a/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
+++ b/android/src/main/java/com/bleclient/plugin/BluetoothLEClient.java
@@ -331,17 +331,14 @@ public class BluetoothLEClient extends Plugin {
 
             byte[] characteristicValue = characteristic.getValue();
 
-
-            Integer characteristic16BitUuid = get16BitUUID(characteristicUuid);
-
-            if (characteristic16BitUuid == null) {
+            if (characteristicUuid == null) {
                 return;
             }
 
             JSObject ret = new JSObject();
             addProperty(ret, keyValue, jsByteArray(characteristicValue));
 
-            notifyListeners(characteristic16BitUuid.toString(), ret);
+            notifyListeners(characteristicUuid.toString(), ret);
         }
 
         @Override
@@ -453,6 +450,18 @@ public class BluetoothLEClient extends Plugin {
         }
     }
 
+    private class AnyUuid {
+        final Integer intValue;
+        final String stringValue;
+        final Boolean isValid;
+
+        AnyUuid(PluginCall call, String key) {
+            this.intValue = call.getInt(key);
+            this.stringValue = call.getString(key);
+            this.isValid = !(this.intValue == null && this.stringValue == null);
+        }
+    }
+
     @Override
     protected void handleOnStart() {
         BluetoothManager bluetoothManager = (BluetoothManager) getContext().getSystemService(Context.BLUETOOTH_SERVICE);
@@ -509,7 +518,7 @@ public class BluetoothLEClient extends Plugin {
                 .build();
 
 
-        ArrayList<UUID> uuids = getServiceUuids(call.getArray(keyServices));
+        List<UUID> uuids = getServiceUuids(call.getArray(keyServices));
 
         List<ScanFilter> filters = new ArrayList<ScanFilter>();
 
@@ -655,9 +664,9 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -671,9 +680,9 @@ public class BluetoothLEClient extends Plugin {
             return;
         }
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
@@ -748,9 +757,9 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -764,16 +773,16 @@ public class BluetoothLEClient extends Plugin {
             return;
         }
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
 
-        UUID charactristicUuid = get128BitUUID(propertyCharacteristic);
+        UUID characteristicUuid = get128BitUUID(propertyCharacteristic);
 
-        BluetoothGattCharacteristic characteristic = service.getCharacteristic(charactristicUuid);
+        BluetoothGattCharacteristic characteristic = service.getCharacteristic(characteristicUuid);
 
         if (characteristic == null) {
             call.reject(keyErrorCharacteristicNotFound);
@@ -832,16 +841,16 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -976,23 +985,23 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
 
-        Integer propertyDescriptor = call.getInt(keyDescriptor);
+        AnyUuid propertyDescriptor = getUuid(call, keyDescriptor);
 
-        if (propertyDescriptor == null) {
+        if (!propertyDescriptor.isValid) {
             call.reject(keyErrorDescriptorMissing);
             return;
         }
@@ -1083,9 +1092,9 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt peripheral = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyUuid);
+        AnyUuid propertyService = getUuid(call, keyUuid);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -1119,9 +1128,9 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -1166,9 +1175,9 @@ public class BluetoothLEClient extends Plugin {
 
         BluetoothGatt gatt = (BluetoothGatt) connection.get(keyPeripheral);
 
-        Integer propertyService = call.getInt(keyService);
+        AnyUuid propertyService = getUuid(call, keyService);
 
-        if (propertyService == null) {
+        if (!propertyService.isValid) {
             call.reject(keyErrorServiceMissing);
             return;
         }
@@ -1180,9 +1189,9 @@ public class BluetoothLEClient extends Plugin {
             return;
         }
 
-        Integer propertyCharacteristic = call.getInt(keyCharacteristic);
+        AnyUuid propertyCharacteristic = getUuid(call, keyCharacteristic);
 
-        if (propertyCharacteristic == null) {
+        if (!propertyCharacteristic.isValid) {
             call.reject(keyErrorCharacteristicMissing);
             return;
         }
@@ -1235,7 +1244,7 @@ public class BluetoothLEClient extends Plugin {
     private JSObject createJSBluetoothGattService(BluetoothGattService service) {
         JSObject retService = new JSObject();
 
-        addProperty(retService, keyUuid, get16BitUUID(service.getUuid()));
+        addProperty(retService, keyUuid, service.getUuid().toString());
 
         if (service.getType() == BluetoothGattService.SERVICE_TYPE_PRIMARY) {
             addProperty(retService, keyIsPrimaryService, true);
@@ -1244,20 +1253,20 @@ public class BluetoothLEClient extends Plugin {
         }
 
 
-        ArrayList<Integer> included = new ArrayList<>();
+        ArrayList<String> included = new ArrayList<>();
         List<BluetoothGattService> subServices = service.getIncludedServices();
 
         for (BluetoothGattService incService : subServices) {
-            included.add(get16BitUUID(incService.getUuid()));
+            included.add(incService.getUuid().toString());
         }
 
         retService.put(keyIncludedServices, JSArray.from(included.toArray()));
 
-        ArrayList<Integer> retCharacteristics = new ArrayList<>();
+        ArrayList<String> retCharacteristics = new ArrayList<>();
         List<BluetoothGattCharacteristic> characteristics = service.getCharacteristics();
 
         for (BluetoothGattCharacteristic characteristic : characteristics) {
-            retCharacteristics.add(get16BitUUID(characteristic.getUuid()));
+            retCharacteristics.add(characteristic.getUuid().toString());
         }
 
         retService.put(keyCharacteristics, JSArray.from(retCharacteristics.toArray()));
@@ -1269,14 +1278,14 @@ public class BluetoothLEClient extends Plugin {
 
         JSObject retCharacteristic = new JSObject();
 
-        addProperty(retCharacteristic, keyUuid, get16BitUUID(characteristic.getUuid()));
+        addProperty(retCharacteristic, keyUuid, characteristic.getUuid().toString());
         addProperty(retCharacteristic, keyCharacteristicProperies, getCharacteristicProperties(characteristic));
 
         List<BluetoothGattDescriptor> descriptors = characteristic.getDescriptors();
-        ArrayList<Integer> descriptorUuids = new ArrayList<>();
+        ArrayList<String> descriptorUuids = new ArrayList<>();
 
         for (BluetoothGattDescriptor descriptor : descriptors) {
-            descriptorUuids.add(get16BitUUID(descriptor.getUuid()));
+            descriptorUuids.add(descriptor.getUuid().toString());
         }
 
         addProperty(retCharacteristic, keyCharacterisicDescripors, JSArray.from(descriptorUuids.toArray()));
@@ -1380,22 +1389,60 @@ public class BluetoothLEClient extends Plugin {
         return JSArray.from(ints);
     }
 
+    private AnyUuid getUuid(PluginCall call, String key) {
+        return new AnyUuid(call, key);
+    }
 
-        ArrayList<UUID> serviceUuids = new ArrayList<>();
     private List<UUID> getServiceUuids(JSArray serviceUuidArray) {
 
-        if (serviceUuidArray == null) {
-            return serviceUuids;
-        }
 
-        List<Integer> uuidList;
+        ArrayList<UUID> emptyList = new ArrayList<>();
+
+        if (serviceUuidArray == null) {
+            return emptyList;
+        }
 
         try {
-            uuidList = serviceUuidArray.toList();
-        } catch (JSONException e) {
+            return getServiceUuidsFromIntegers(serviceUuidArray);
+        } catch (Exception e) {
+            // fallthrough
+        }
+
+        try {
+            return getServiceUuidsFromStrings(serviceUuidArray);
+        } catch (JSONException ee) {
             Log.e(getLogTag(), "Error while converting JSArray to List");
+            return emptyList;
+        } catch (IllegalArgumentException eee) {
+            Log.e(getLogTag(), "Invalid uuid string");
+            return emptyList;
+        }
+    }
+
+    private List<UUID> getServiceUuidsFromStrings(JSArray serviceUuidArray) throws JSONException {
+        List<UUID> serviceUuids = new ArrayList<>();
+        List<String> uuidList = serviceUuidArray.toList();
+
+        if (!(uuidList.size() > 0)) {
+            Log.i(getLogTag(), "No uuids given");
             return serviceUuids;
         }
+
+        for (String uuid : uuidList) {
+
+            UUID uuid128 = get128BitUUID(uuid);
+
+            if (uuid128 != null) {
+                serviceUuids.add(uuid128);
+            }
+        }
+
+        return serviceUuids;
+    }
+
+    private List<UUID> getServiceUuidsFromIntegers(JSArray serviceUuidArray) throws JSONException {
+        List<UUID> serviceUuids = new ArrayList<>();
+        List<Integer> uuidList = serviceUuidArray.toList();
 
         if (!(uuidList.size() > 0)) {
             Log.i(getLogTag(), "No uuids given");
@@ -1462,6 +1509,22 @@ public class BluetoothLEClient extends Plugin {
         return UUID.fromString(uuidString);
 
 
+    }
+
+    private UUID get128BitUUID(String uuid) {
+        return UUID.fromString(uuid);
+    }
+
+    private UUID get128BitUUID(AnyUuid uuid) {
+        if (!uuid.isValid) {
+            return null;
+        }
+
+        if (uuid.intValue != null) {
+            return get128BitUUID(uuid.intValue);
+        }
+
+        return get128BitUUID(uuid.stringValue);
     }
 
     private int get16BitUUID(UUID uuid) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -66,6 +66,7 @@ export type BluetoothGATTEnableResult = {
 
 export interface BluetoothGATTScanOptions{
   services: Array<BluetoothGATTService>
+  optionalServices: Array<BluetoothGATTService>
 }
 
 export interface BluetoothGATTPeripheral{

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -49,6 +49,9 @@ export interface BluetoothLEClientPlugin extends WebPlugin{
 
 }
 
+export type BluetoothGATTService = BluetoothGATTServices | number | string;
+export type BluetoothGATTCharacteristic = BluetoothGATTCharacteristics | number | string;
+
 export interface BluetoothGATTAvailabilityResult{
   isAvailable: boolean
 }
@@ -62,7 +65,7 @@ export type BluetoothGATTEnableResult = {
 }
 
 export interface BluetoothGATTScanOptions{
-  services: Array<BluetoothGATTServices | number>
+  services: Array<BluetoothGATTService>
 }
 
 export interface BluetoothGATTPeripheral{
@@ -103,8 +106,8 @@ export type BluetoothGATTByteData = number[];
 
 export interface BluetoothGATTCharacteristicReadOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic: BluetoothGATTCharacteristics | number
+  service: BluetoothGATTService,
+  characteristic: BluetoothGATTCharacteristic
 }
 
 
@@ -115,8 +118,8 @@ export interface BluetoothGATTCharacteristicReadResult{
 
 export interface BluetoothGATTCharacteristicWriteOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic: BluetoothGATTCharacteristics | number
+  service: BluetoothGATTService,
+  characteristic: BluetoothGATTCharacteristic
   value: string //Base64 encoded string of byte array
 }
 
@@ -126,8 +129,8 @@ export interface BluetoothGATTCharacteristicWriteResult{
 
 export interface BluetoothGATTDescriptorReadOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic: BluetoothGATTCharacteristics | number,
+  service: BluetoothGATTService,
+  characteristic: BluetoothGATTCharacteristic,
   descriptor: number
 }
 
@@ -137,8 +140,8 @@ export interface BluetoothGATTDescriptorReadResult{
 
 export interface BluetoothGATTDescriptorWriteOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic: BluetoothGATTCharacteristics | number,
+  service: BluetoothGATTService,
+  characteristic: BluetoothGATTCharacteristic,
   descriptor: number,
   value: string //Base64 encoded string of byte array
 }
@@ -149,8 +152,8 @@ export interface BluetoothGATTDescriptorWriteResult{
 
 export interface BluetoothGATTNotificationOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic: BluetoothGATTCharacteristics | number,
+  service: BluetoothGATTService,
+  characteristic: BluetoothGATTCharacteristic,
 }
 
 export interface BluetoothGATTEnableNotificationsResult{
@@ -163,22 +166,22 @@ export interface BluetoothGATTDisableNotificationsResult{
 
 export interface GetServiceOptions{
   id:string,
-  service?: BluetoothGATTServices | number
+  service?: BluetoothGATTService
 }
 
 export interface GATTService{
-  uuid: BluetoothGATTServices | number,
+  uuid: string,
   isPrimary: boolean,
-  characteristics: Array<BluetoothGATTCharacteristics | number>,
-  included?: Array<BluetoothGATTServices | number>
+  characteristics: Array<BluetoothGATTCharacteristic>,
+  included?: Array<BluetoothGATTService>
 }
 
 export type GetServiceResult = GATTService | {services: GATTService[]};
 
 export interface GetCharacteristicOptions{
   id: string,
-  service: BluetoothGATTServices | number,
-  characteristic?: BluetoothGATTCharacteristics | number
+  service: BluetoothGATTService,
+  characteristic?: BluetoothGATTCharacteristic
 }
 
 export interface GATTCharacteristicProperties{
@@ -194,9 +197,9 @@ export interface GATTCharacteristicProperties{
 }
 
 export interface GATTCharacteristic{
-  uuid: BluetoothGATTCharacteristics | number,
+  uuid: BluetoothGATTCharacteristic,
   properties: GATTCharacteristicProperties,
-  descriptors: number[]
+  descriptors: string[]
 }
 
 export type GetCharacteristicResult = GATTCharacteristic | {characteristics: GATTCharacteristic[]};

--- a/src/utils/base64.d.ts
+++ b/src/utils/base64.d.ts
@@ -1,0 +1,2 @@
+export declare function bytesToBase64(bytes: Uint8Array): string;
+export declare function base64ToBytes(base64: string): Uint8Array;

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -1,0 +1,103 @@
+"use strict";
+
+/*\
+|*|
+|*|  Base64 / binary data / UTF-8 strings utilities (#1)
+|*|
+|*|  https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+|*|
+|*|  Author: madmurphy
+|*|
+\*/
+
+/* Array of bytes to base64 string decoding */
+
+function b64ToUint6(nChr) {
+  return nChr > 64 && nChr < 91
+    ? nChr - 65
+    : nChr > 96 && nChr < 123
+    ? nChr - 71
+    : nChr > 47 && nChr < 58
+    ? nChr + 4
+    : nChr === 43
+    ? 62
+    : nChr === 47
+    ? 63
+    : 0;
+}
+
+function base64DecToArr(sBase64, nBlockSize) {
+  const sB64Enc = sBase64.replace(/[^A-Za-z0-9\+\/]/g, ""),
+    nInLen = sB64Enc.length,
+    nOutLen = nBlockSize
+      ? Math.ceil(((nInLen * 3 + 1) >>> 2) / nBlockSize) * nBlockSize
+      : (nInLen * 3 + 1) >>> 2,
+    aBytes = new Uint8Array(nOutLen);
+
+  for (
+    var nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0;
+    nInIdx < nInLen;
+    nInIdx++
+  ) {
+    nMod4 = nInIdx & 3;
+    nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << (18 - 6 * nMod4);
+    if (nMod4 === 3 || nInLen - nInIdx === 1) {
+      for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
+        aBytes[nOutIdx] = (nUint24 >>> ((16 >>> nMod3) & 24)) & 255;
+      }
+      nUint24 = 0;
+    }
+  }
+
+  return aBytes;
+}
+
+/* Base64 string to array encoding */
+
+function uint6ToB64(nUint6) {
+  return nUint6 < 26
+    ? nUint6 + 65
+    : nUint6 < 52
+    ? nUint6 + 71
+    : nUint6 < 62
+    ? nUint6 - 4
+    : nUint6 === 62
+    ? 43
+    : nUint6 === 63
+    ? 47
+    : 65;
+}
+
+function base64EncArr(aBytes) {
+  let eqLen = (3 - (aBytes.length % 3)) % 3,
+    sB64Enc = "";
+
+  for (
+    var nMod3, nLen = aBytes.length, nUint24 = 0, nIdx = 0;
+    nIdx < nLen;
+    nIdx++
+  ) {
+    nMod3 = nIdx % 3;
+    /* Uncomment the following line in order to split the output in lines 76-character long: */
+    /*
+    if (nIdx > 0 && (nIdx * 4 / 3) % 76 === 0) { sB64Enc += "\r\n"; }
+    */
+    nUint24 |= aBytes[nIdx] << ((16 >>> nMod3) & 24);
+    if (nMod3 === 2 || aBytes.length - nIdx === 1) {
+      sB64Enc += String.fromCharCode(
+        uint6ToB64((nUint24 >>> 18) & 63),
+        uint6ToB64((nUint24 >>> 12) & 63),
+        uint6ToB64((nUint24 >>> 6) & 63),
+        uint6ToB64(nUint24 & 63)
+      );
+      nUint24 = 0;
+    }
+  }
+
+  return eqLen === 0
+    ? sB64Enc
+    : sB64Enc.substring(0, sB64Enc.length - eqLen) + (eqLen === 1 ? "=" : "==");
+}
+
+export { base64EncArr as bytesToBase64 };
+export { base64DecToArr as base64ToBytes };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,11 +1,6 @@
 import {BluetoothGATTByteData} from "../definitions";
 
-export const get16BitUUID = (uuid: string) => {
-    const prefix = "0x";
-    const id = uuid.substr(4,4);
-    return parseInt(prefix.concat(id));
 export * from "./base64";
-};
 
 export const toDataView = (value: BluetoothGATTByteData) => {
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ export const get16BitUUID = (uuid: string) => {
     const prefix = "0x";
     const id = uuid.substr(4,4);
     return parseInt(prefix.concat(id));
+export * from "./base64";
 };
 
 export const toDataView = (value: BluetoothGATTByteData) => {

--- a/src/web.ts
+++ b/src/web.ts
@@ -85,7 +85,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
     const filters = options.services.map((service) => {
       return {services: [service]};
     });
-    const optionalServices: number[] = options.services || [];
+    const optionalServices: BluetoothGATTService[] = options.services || [];
 
     try {
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -20,6 +20,7 @@ import {
   BluetoothGATTNotificationOptions,
   BluetoothGATTScanOptions,
   BluetoothGATTScanResults,
+  BluetoothGATTService,
   BluetoothGATTServiceDiscoveryOptions,
   BluetoothGATTServiceDiscoveryResult,
   BluetoothLEClientPlugin,
@@ -27,10 +28,9 @@ import {
   GetCharacteristicOptions,
   GetCharacteristicResult,
   GetServiceOptions,
-  GetServiceResult
+  GetServiceResult,
+  BluetoothGATTCharacteristic
 } from './definitions';
-import {get16BitUUID} from "./utils/utils";
-import {BluetoothGATTCharacteristics} from "./utils/ble-gatt-characteristics.enum";
 import {base64ToBytes} from "./utils/utils";
 import {NotConnectedError, OptionsRequiredError} from "./utils/errors";
 
@@ -41,6 +41,8 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
   private devices: Map<string, BluetoothDevice> = new Map();
 
   private connections: Map<string, any> = new Map();
+
+  private characteristicListeners: Map<string, (ev: Event) => void> = new Map();
 
   constructor() {
     super({
@@ -288,25 +290,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       let gattCharacterisic: BluetoothRemoteGATTCharacteristic = await gattService.getCharacteristic(characteristic);
 
       gattCharacterisic = await gattCharacterisic.startNotifications();
-
-      gattCharacterisic.addEventListener("characteristicvaluechanged", (ev) => {
-
-        const char: BluetoothRemoteGATTCharacteristic = (ev.target) as BluetoothRemoteGATTCharacteristic;
-        const serv: BluetoothRemoteGATTService = char.service;
-        const dev: BluetoothDevice = serv.device;
-        const value = [...(new Uint8Array(char.value.buffer))];
-
-        const meta = {
-          id: dev.id,
-          service: get16BitUUID(serv.uuid),
-          characteristic: get16BitUUID(char.uuid)
-        };
-
-        this.notifyListeners(get16BitUUID(char.uuid).toString(), {...meta, value});
-      });
-
-
-
+      this.addCharacteristicValueChangedListener(gattCharacterisic);
       return {enabled: true};
     }catch (e) {
       return Promise.reject(e);
@@ -328,6 +312,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       const gattService: BluetoothRemoteGATTService = await gatt.getPrimaryService(service);
       const gattCharacteristic: BluetoothRemoteGATTCharacteristic = await gattService.getCharacteristic(characteristic);
       await gattCharacteristic.stopNotifications();
+      this.removeCharacteristicValueChangedListener(gattCharacteristic);
       return {disabled: true};
     } catch (e) {
       return Promise.reject(e);
@@ -354,7 +339,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
         const characteristics = await this.getIncludedCharacteristicUuids(service);
 
         return {
-          uuid: get16BitUUID(service.uuid),
+          uuid: service.uuid,
           isPrimary: service.isPrimary,
           characteristics
         };
@@ -385,7 +370,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       const {uuid, isPrimary} = gattService;
 
       return {
-        uuid: get16BitUUID(uuid),
+        uuid,
         isPrimary,
         characteristics
       }
@@ -421,7 +406,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
         const properties = this.getCharacteristicProperties(characteristic);
 
         return {
-          uuid: get16BitUUID(uuid),
+          uuid,
           properties,
           descriptors
         }
@@ -453,7 +438,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       const gattCharacteristic = await gattService.getCharacteristic(characteristic);
       const descriptors = await this.getIncludedDescriptorUuids(gattCharacteristic);
       const properties = this.getCharacteristicProperties(gattCharacteristic);
-      const uuid = get16BitUUID(gattCharacteristic.uuid);
+      const uuid = gattCharacteristic.uuid;
 
       return {
         uuid,
@@ -504,7 +489,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
     };
   }
 
-  private async getIncludedCharacteristicUuids(service: BluetoothRemoteGATTService): Promise<Array<BluetoothGATTCharacteristics | number>> {
+  private async getIncludedCharacteristicUuids(service: BluetoothRemoteGATTService): Promise<Array<BluetoothGATTCharacteristic>> {
     let characteristics: BluetoothRemoteGATTCharacteristic[] = [];
 
     try {
@@ -513,10 +498,10 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       return Promise.reject(e);
     }
 
-    return characteristics.map((characteristic) => get16BitUUID(characteristic.uuid));
+    return characteristics.map((characteristic) => characteristic.uuid);
   }
 
-  private async getIncludedDescriptorUuids(characteristic: BluetoothRemoteGATTCharacteristic): Promise<number[]>{
+  private async getIncludedDescriptorUuids(characteristic: BluetoothRemoteGATTCharacteristic): Promise<string[]>{
 
     let descriptors: BluetoothRemoteGATTDescriptor [] = [];
 
@@ -526,10 +511,38 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       console.log(e);
     }
 
-    return descriptors.map((descriptor) => get16BitUUID(descriptor.uuid));
+    return descriptors.map((descriptor) => descriptor.uuid);
   }
 
+  private addCharacteristicValueChangedListener(gattCharacterisic: BluetoothRemoteGATTCharacteristic): void {
+    const uuid = gattCharacterisic.uuid;
 
+    if (!this.characteristicListeners.get(uuid)) {
+      this.characteristicListeners.set(uuid, (ev) => {
+        const char: BluetoothRemoteGATTCharacteristic = (ev.target) as BluetoothRemoteGATTCharacteristic;
+        const serv: BluetoothRemoteGATTService = char.service;
+        const dev: BluetoothDevice = serv.device;
+        const value = [...(new Uint8Array(char.value.buffer))];
+
+        const meta = {
+          id: dev.id,
+          service: serv.uuid,
+          characteristic: char.uuid
+        };
+
+        this.notifyListeners(char.uuid, {...meta, value});
+      });
+
+      gattCharacterisic.addEventListener("characteristicvaluechanged", this.characteristicListeners.get(uuid));
+    }
+  }
+
+  private removeCharacteristicValueChangedListener(gattCharacteristic: BluetoothRemoteGATTCharacteristic): void {
+    const uuid = gattCharacteristic.uuid;
+    const listener = this.characteristicListeners.get(uuid);
+    gattCharacteristic.removeEventListener("characteristicvaluechanged", listener);
+    this.characteristicListeners.delete(uuid);
+  }
 
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -31,6 +31,7 @@ import {
 } from './definitions';
 import {get16BitUUID} from "./utils/utils";
 import {BluetoothGATTCharacteristics} from "./utils/ble-gatt-characteristics.enum";
+import {base64ToBytes} from "./utils/utils";
 import {NotConnectedError, OptionsRequiredError} from "./utils/errors";
 
 const nav: Navigator = navigator;
@@ -194,8 +195,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       const gattService: BluetoothRemoteGATTService = await gatt.getPrimaryService(service);
       const gattCharacteristic: BluetoothRemoteGATTCharacteristic = await gattService.getCharacteristic(characteristic);
 
-      const encoder = new TextEncoder();
-      const toWrite = encoder.encode(value);
+      const toWrite = base64ToBytes(value);
 
       await gattCharacteristic.writeValue(toWrite)
 
@@ -256,8 +256,7 @@ export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClient
       const gattCharacteristic: BluetoothRemoteGATTCharacteristic = await gattService.getCharacteristic(characteristic);
       const gattDescriptor: BluetoothRemoteGATTDescriptor = await gattCharacteristic.getDescriptor(descriptor);
 
-      const encoder = new TextEncoder();
-      const toWrite = encoder.encode(value);
+      const toWrite = base64ToBytes(value);
 
       await gattDescriptor.writeValue(toWrite);
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -34,7 +34,23 @@ import {
 import {base64ToBytes} from "./utils/utils";
 import {NotConnectedError, OptionsRequiredError} from "./utils/errors";
 
-const nav: Navigator = navigator;
+interface BluetoothProvider {
+  bluetooth: {
+    requestDevice: (options: {
+      filters: Array<{services: Array<BluetoothGATTService>}>,
+      optionalServices: Array<BluetoothGATTService>,
+      acceptAllDevices: boolean
+    }) => Promise<BluetoothDevice>;
+  }
+}
+
+// If this browser does not support bluetooth, don't fail unless we try to use it
+const nav: BluetoothProvider =
+  typeof navigator === "undefined"
+    ? { bluetooth: { requestDevice: () => {
+      throw new Error("Bluetooth is not supported");
+    } } }
+    : navigator;
 
 export class BluetoothLEClientWeb extends WebPlugin implements BluetoothLEClientPlugin {
 


### PR DESCRIPTION
Currently, this library throws an error when it is loaded in a browser that doesn't support web bluetooth. This commit allows the page to load, and only throws an error if a user tries to actually use bluetooth.

This is also helpful in testing, in case your dependencies are not totally isolated.